### PR TITLE
EZP-30484: Skip attributes with zero instances in the ezmatrix migrat…

### DIFF
--- a/src/bundle/Command/MigrateLegacyMatrixCommand.php
+++ b/src/bundle/Command/MigrateLegacyMatrixCommand.php
@@ -142,6 +142,11 @@ class MigrateLegacyMatrixCommand extends Command
                 (int)$contentClassAttribute['id']
             );
 
+            if ($contentAttributesCount === 0) {
+                $io->comment(sprintf('Zero instances of %s:%s attribute to migrate.', $contentClassAttribute['contenttype_identifier'], $contentClassAttribute['identifier']));
+                continue;
+            }
+
             $columns = json_decode($columnsJson);
 
             $progressBar = $this->getProgressBar($contentAttributesCount, $output);


### PR DESCRIPTION
This fixes https://jira.ez.no/browse/EZP-30484:

When running `php bin/console ezplatform:migrate:legacy_matrix` (https://github.com/ezsystems/ezplatform-matrix-fieldtype/blob/107e3588eebb7ab78033c64e549cefb01146c105/src/bundle/Command/MigrateLegacyMatrixCommand.php), the script errors out if there are 0 instances of the content object / content object attribute:

[Symfony\Component\Console\Exception\LogicException]                         
Unable to display the estimated time if the maximum number of steps is not set.
