### PR TITLE
EZP-30626: Change FieldType::getName() arguments

### DIFF
--- a/src/lib/FieldType/Type.php
+++ b/src/lib/FieldType/Type.php
@@ -115,7 +115,7 @@ class Type extends FieldType
     /**
      * {@inheritdoc}
      */
-    public function getName(SPIValue $value): string
+    public function getName(SPIValue $value, FieldDefinition $fieldDefinition, string $languageCode): string
     {
         return '';
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30626](https://jira.ez.no/browse/EZP-30626)
| **Improvement**| no
| **New feature**    | yes
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |no

This PR adjust FieldType::getName() arguments to be compatible with `eZ\Publish\Core\FieldType\FieldType`

Related to: [https://github.com/ezsystems/ezpublish-kernel/pull/2661](https://github.com/ezsystems/ezpublish-kernel/pull/2661)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [] Ask for Code Review.
