### PR TITLE
EZP-30462: Aligned Field Type service tags with new naming convention

### DIFF
--- a/src/bundle/Resources/config/services/fieldtype.yaml
+++ b/src/bundle/Resources/config/services/fieldtype.yaml
@@ -15,13 +15,13 @@ services:
         arguments:
             $fieldTypeIdentifier: '%ezplatform.fieldtype.matrix.identifier%'
         tags:
-            - { name: ezpublish.fieldType, alias: '%ezplatform.fieldtype.matrix.identifier%' }
+            - { name: ezplatform.field_type, alias: '%ezplatform.fieldtype.matrix.identifier%' }
 
     EzSystems\EzPlatformMatrixFieldtype\FieldType\Converter\MatrixConverter:
         tags:
-            - { name: ezpublish.storageEngine.legacy.converter, alias: '%ezplatform.fieldtype.matrix.identifier%' }
+            - { name: ezplatform.field_type.legacy_storage.converter, alias: '%ezplatform.fieldtype.matrix.identifier%' }
 
     EzSystems\EzPlatformMatrixFieldtype\FieldType\Mapper\MatrixFormMapper:
         tags:
-            - { name: ez.fieldFormMapper.definition, fieldType: '%ezplatform.fieldtype.matrix.identifier%' }
-            - { name: ez.fieldFormMapper.value, fieldType: '%ezplatform.fieldtype.matrix.identifier%' }
+            - { name: ezplatform.field_type.form_mapper.definition, fieldType: '%ezplatform.fieldtype.matrix.identifier%' }
+            - { name: ezplatform.field_type.form_mapper.value, fieldType: '%ezplatform.fieldtype.matrix.identifier%' }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30462](https://jira.ez.no/browse/EZP-30462)
| **Improvement**| yes
| **New feature**    |no
| **Target version** | `master`
| **BC breaks**      |no
| **Tests pass**     | yes/no
| **Doc needed**     | yes

Tags used to register Field Type features in the dependency injection container should be consistent and follow Symfony convention (snake case)

```
ezpublish.fieldType => ezplatform.field_type
ezpublish.fieldType.indexable => ezplatform.field_type.indexable
ezpublish.storageEngine.legacy.converter => ezplatform.field_type.legacy_storage.converter
ezpublish.fieldType.parameterProvider => ezplatform.field_type.parameter_provider
ezpublish_rest.field_type_processor => ezplatform.field_type.rest.processor
ez.fieldFormMapper.value => ezplatform.field_type.form_mapper.value
ez.fieldFormMapper.definition => ezplatform.field_type.form_mapper.definition
```

Related PR: 
[https://github.com/ezsystems/repository-forms/pull/292](https://github.com/ezsystems/repository-forms/pull/292)
[https://github.com/ezsystems/ezpublish-kernel/pull/2653](https://github.com/ezsystems/ezpublish-kernel/pull/2653)

QA: We have to make sure that all field types work correctly

**TODO**:
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
