### PR TITLE
 EZP-30814: Removed Twig deprecations

### DIFF
--- a/src/bundle/Resources/views/themes/standard/matrix_fieldtype/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/standard/matrix_fieldtype/content_fields.html.twig
@@ -1,5 +1,5 @@
 {% block ezmatrix_field %}
-{% spaceless %}
+{% apply spaceless %}
     {% set columnsSettings = content.contentType.fieldDefinitionsByIdentifier[field.fieldDefIdentifier].fieldSettings['columns'] %}
     {% set fieldData = field.value.rows %}
 
@@ -21,5 +21,5 @@
         {% endfor %}
         </tbody>
     </table>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30814

## Description

Continuation of https://github.com/ezsystems/ezpublish-kernel/pull/2708:

* Replaced `spaceless` tag usages in favour of `spaceless` filter
