### PR TITLE
GraphQL support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     },
     "require": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "ezsystems/ezplatform-graphql": "^1.0.4@dev"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.7.1",

--- a/src/bundle/Resources/config/graphql/types/MatrixFieldDefinition.types.yml
+++ b/src/bundle/Resources/config/graphql/types/MatrixFieldDefinition.types.yml
@@ -1,0 +1,26 @@
+MatrixFieldDefinition:
+    type: object
+    config:
+        fields:
+            settings:
+                type: MatrixFieldDefinitionSettings
+                resolve: "@=value.getFieldSettings()"
+
+MatrixFieldDefinitionSettings:
+    type: object
+    config:
+        fields:
+            columns:
+                type: "[MatrixFieldDefinitionColumn]"
+            minimumRows:
+                type: "Int"
+                resolve: "@=value['minimum_rows']"
+
+MatrixFieldDefinitionColumn:
+    type: object
+    config:
+        fields:
+            name:
+                type: String
+            identifier:
+                type: String

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,3 +1,4 @@
 imports:
     - { resource: services/fieldtype.yml }
     - { resource: services/migration.yml }
+    - { resource: services/graphql.yml }

--- a/src/bundle/Resources/config/services/graphql.yml
+++ b/src/bundle/Resources/config/services/graphql.yml
@@ -1,0 +1,26 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\MatrixFieldDefinitionMapper:
+        decorates: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
+        arguments:
+            $innerMapper: '@EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\MatrixFieldDefinitionMapper.inner'
+        tags:
+            - { name: ezplatform_graphql.field_definition_input_mapper, fieldtype: ezmatrix }
+
+    EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper: ~
+
+    EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\MatrixFieldDefinitionSchemaWorker:
+        tags:
+            - { name: ezplatform_graphql.domain_schema_worker }
+
+    EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\MatrixFieldDefinitionInputSchemaWorker:
+        tags:
+            - { name: ezplatform_graphql.domain_schema_worker }
+
+    EzSystems\EzPlatformMatrixFieldtype\GraphQL\InputHandler:
+        tags:
+            - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: ezmatrix }

--- a/src/bundle/Resources/config/services/graphql.yml
+++ b/src/bundle/Resources/config/services/graphql.yml
@@ -24,3 +24,7 @@ services:
     EzSystems\EzPlatformMatrixFieldtype\GraphQL\InputHandler:
         tags:
             - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: ezmatrix }
+
+    EzSystems\EzPlatformMatrixFieldtype\GraphQL\FieldValueResolver:
+        tags:
+            - {name: overblog_graphql.resolver, alias: "MatrixFieldValue", method: "resolveMatrixFieldValue"}

--- a/src/lib/GraphQL/FieldValueResolver.php
+++ b/src/lib/GraphQL/FieldValueResolver.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\EzPlatformMatrixFieldtype\GraphQL;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use EzSystems\EzPlatformMatrixFieldtype\FieldType\Value\RowsCollection;
+
+class FieldValueResolver
+{
+    public function resolveMatrixFieldValue(Content $content, string $fieldDefIdentifier): RowsCollection
+    {
+        $silentRows = [];
+
+        /** @var RowsCollection $rows $rows */
+        $rows = $content->getFieldValue($fieldDefIdentifier)->getRows();
+        foreach ($rows as $row) {
+            $silentRows[] = new SilentRow($row->getCells());
+        }
+        return new RowsCollection($silentRows);
+    }
+}

--- a/src/lib/GraphQL/InputHandler.php
+++ b/src/lib/GraphQL/InputHandler.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformMatrixFieldtype\GraphQL;
+
+use eZ\Publish\SPI\FieldType\Value;
+use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldTypeInputHandler;
+use EzSystems\EzPlatformMatrixFieldtype\FieldType\Value as MatrixValue;
+
+class InputHandler implements FieldTypeInputHandler
+{
+    public function toFieldValue($input, $inputFormat = null): Value
+    {
+        return new MatrixValue(
+            array_map(
+                function (array $row) {
+                    return new MatrixValue\Row($row);
+                },
+                $input
+            )
+        );
+    }
+}

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionInputSchemaWorker.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionInputSchemaWorker.php
@@ -14,9 +14,7 @@ use EzSystems\EzPlatformGraphQL\Schema\Worker;
 
 class MatrixFieldDefinitionInputSchemaWorker implements Worker
 {
-    /**
-     * @var \EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper
-     */
+    /** @var \EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper */
     private $nameHelper;
 
     public function __construct(NameHelper $nameHelper)

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionInputSchemaWorker.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionInputSchemaWorker.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use EzSystems\EzPlatformGraphQL\Schema\Builder;
+use EzSystems\EzPlatformGraphQL\Schema\Worker;
+
+class MatrixFieldDefinitionInputSchemaWorker implements Worker
+{
+    /**
+     * @var \EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper
+     */
+    private $nameHelper;
+
+    public function __construct(NameHelper $nameHelper)
+    {
+        $this->nameHelper = $nameHelper;
+    }
+
+    public function work(Builder $schema, array $args)
+    {
+        $typeName = $this->typeName($args);
+        $schema->addType(new Builder\Input\Type($typeName, 'input-object'));
+
+        /** @var FieldDefinition $fieldDefinition */
+        $fieldDefinition = $args['FieldDefinition'];
+        foreach ($fieldDefinition->getFieldSettings()['columns'] as $column) {
+            $schema->addFieldToType(
+                $typeName,
+                new Builder\Input\Field(
+                    $column['identifier'],
+                    'String',
+                    ['description' => $column['name']]
+                ));
+        }
+    }
+
+    public function canWork(Builder $schema, array $args)
+    {
+        return
+            isset($args['ContentType'])
+            && $args['ContentType'] instanceof ContentType
+            && isset($args['FieldDefinition'])
+            && $args['FieldDefinition'] instanceof FieldDefinition
+            && $args['FieldDefinition']->fieldTypeIdentifier === 'ezmatrix'
+            && !$schema->hasType($this->typeName($args));
+    }
+
+    private function typeName(array $args)
+    {
+        return $this->nameHelper->matrixFieldDefinitionInputType($args['ContentType'], $args['FieldDefinition']);
+    }
+}

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionMapper.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionMapper.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\DecoratingFieldDefinitionMapper;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionInputMapper;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
+
+class MatrixFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper, FieldDefinitionInputMapper
+{
+    /**
+     * @var \EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper
+     */
+    private $nameHelper;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
+    private $contentTypeService;
+
+    public function __construct(FieldDefinitionMapper $innerMapper, NameHelper $nameHelper, ContentTypeService $contentTypeService)
+    {
+        parent::__construct($innerMapper);
+        $this->nameHelper = $nameHelper;
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    public function mapToFieldDefinitionType(FieldDefinition $fieldDefinition): ?string
+    {
+        return 'MatrixFieldDefinition';
+    }
+
+    protected function getFieldTypeIdentifier(): string
+    {
+        return 'ezmatrix';
+    }
+
+    public function mapToFieldValueType(FieldDefinition $fieldDefinition): ?string
+    {
+        if (!$this->canMap($fieldDefinition)) {
+            return parent::mapToFieldValueType($fieldDefinition);
+        }
+
+        return sprintf(
+            '[%s]',
+            $this->nameHelper->matrixFieldDefinitionType($this->findContentTypeOf($fieldDefinition), $fieldDefinition)
+        );
+    }
+
+    public function mapToFieldValueInputType(ContentType $contentType, FieldDefinition $fieldDefinition): ?string
+    {
+        if (!$this->canMap($fieldDefinition) && \is_callable('parent::mapToFieldValueInputType')) {
+            return parent::mapToFieldValueInputType($contentType, $fieldDefinition);
+        }
+
+        return sprintf('[%s]', $this->nameHelper->matrixFieldDefinitionInputType($contentType, $fieldDefinition));
+    }
+
+    public function mapToFieldValueResolver(FieldDefinition $fieldDefinition): ?string
+    {
+        if (!$this->canMap($fieldDefinition)) {
+            return parent::mapToFieldValueResolver($fieldDefinition);
+        }
+
+        return sprintf(
+            '@=resolver("DomainFieldValue", [value, "%s"]).value.getRows()',
+            $fieldDefinition->identifier
+        );
+    }
+
+    private function findContentTypeOf(FieldDefinition $fieldDefinition): ContentType
+    {
+        foreach ($this->contentTypeService->loadContentTypeGroups() as $group) {
+            foreach ($this->contentTypeService->loadContentTypes($group) as $type) {
+                $foundFieldDefinition = $type->getFieldDefinition($fieldDefinition->identifier);
+                if ($foundFieldDefinition === null) {
+                    continue;
+                }
+                if ($foundFieldDefinition->id === $fieldDefinition->id) {
+                    return $type;
+                }
+            }
+        }
+
+        throw new \Exception('Could not find content type for field definition');
+    }
+}

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionMapper.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionMapper.php
@@ -67,8 +67,11 @@ class MatrixFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implem
             return parent::mapToFieldValueResolver($fieldDefinition);
         }
 
+        // At this point 'value' is the Content item.
+        // We can't "pass the definition" to the resolver. We need the columns names. Pass them to the resolver ??
+        // An alternative is to
         return sprintf(
-            '@=resolver("DomainFieldValue", [value, "%s"]).value.getRows()',
+            '@=resolver("MatrixFieldValue", [value, "%s"])',
             $fieldDefinition->identifier
         );
     }

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionMapper.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionMapper.php
@@ -17,14 +17,10 @@ use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\Fie
 
 class MatrixFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper, FieldDefinitionInputMapper
 {
-    /**
-     * @var \EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper
-     */
+    /** @var \EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper */
     private $nameHelper;
 
-    /**
-     * @var \eZ\Publish\API\Repository\ContentTypeService
-     */
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;
 
     public function __construct(FieldDefinitionMapper $innerMapper, NameHelper $nameHelper, ContentTypeService $contentTypeService)

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionSchemaWorker.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionSchemaWorker.php
@@ -15,9 +15,7 @@ use EzSystems\EzPlatformGraphQL\Schema\Worker;
 
 class MatrixFieldDefinitionSchemaWorker implements Worker
 {
-    /**
-     * @var \EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper
-     */
+    /** @var \EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper */
     private $nameHelper;
 
     public function __construct(NameHelper $nameHelper)

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionSchemaWorker.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionSchemaWorker.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use EzSystems\EzPlatformGraphQL\Schema\Builder;
+use EzSystems\EzPlatformGraphQL\Schema\Worker;
+
+class MatrixFieldDefinitionSchemaWorker implements Worker
+{
+    /**
+     * @var \EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema\NameHelper
+     */
+    private $nameHelper;
+
+    public function __construct(NameHelper $nameHelper)
+    {
+        $this->nameHelper = $nameHelper;
+    }
+
+    public function work(Builder $schema, array $args)
+    {
+        $typeName = $this->typeName($args);
+        $schema->addType(new Builder\Input\Type($typeName, 'object'));
+
+        /** @var FieldDefinition $fieldDefinition */
+        $fieldDefinition = $args['FieldDefinition'];
+        foreach ($fieldDefinition->getFieldSettings()['columns'] as $column) {
+            $schema->addFieldToType(
+                $typeName,
+                new Builder\Input\Field(
+                    $column['identifier'],
+                    'String',
+                    ['description' => $column['name']]
+                ));
+        }
+    }
+
+    public function canWork(Builder $schema, array $args)
+    {
+        return
+            isset($args['ContentType'])
+            && $args['ContentType'] instanceof ContentType
+            && isset($args['FieldDefinition'])
+            && $args['FieldDefinition'] instanceof FieldDefinition
+            && $args['FieldDefinition']->fieldTypeIdentifier === 'ezmatrix'
+            && !$schema->hasType($this->typeName($args));
+    }
+
+    private function typeName(array $args)
+    {
+        return $this->nameHelper->matrixFieldDefinitionType($args['ContentType'], $args['FieldDefinition']);
+    }
+}

--- a/src/lib/GraphQL/Schema/NameHelper.php
+++ b/src/lib/GraphQL/Schema/NameHelper.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformMatrixFieldtype\GraphQL\Schema;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+class NameHelper
+{
+    public function matrixFieldDefinitionType(ContentType $contentType, FieldDefinition $fieldDefinition)
+    {
+        $caseConverter = new CamelCaseToSnakeCaseNameConverter(null, false);
+
+        return sprintf(
+            '%s%sRow',
+            $caseConverter->denormalize($contentType->identifier),
+            $caseConverter->denormalize($fieldDefinition->identifier)
+        );
+    }
+
+    public function matrixFieldDefinitionInputType(ContentType $contentType, FieldDefinition $fieldDefinition)
+    {
+        $caseConverter = new CamelCaseToSnakeCaseNameConverter(null, false);
+
+        return sprintf(
+            '%s%sRowInput',
+            $caseConverter->denormalize($contentType->identifier),
+            $caseConverter->denormalize($fieldDefinition->identifier)
+        );
+    }
+}

--- a/src/lib/GraphQL/SilentRow.php
+++ b/src/lib/GraphQL/SilentRow.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+
+namespace EzSystems\EzPlatformMatrixFieldtype\GraphQL;
+
+use EzSystems\EzPlatformMatrixFieldtype\FieldType\Value\Row;
+
+class SilentRow extends Row
+{
+    public function __get($name)
+    {
+        return $this->cells[$name] ?? '';
+    }
+}


### PR DESCRIPTION
> Requires https://github.com/ezsystems/ezplatform-graphql/pull/61 (merged)

Adds GraphQL support to the Matrix field type.

Values and Inputs for matrix fields are generated based on the field definition settings. The types are named after the content type and field definition identifier.

## Examples
With a Product content type that has two fields:
- `name`: `ezstring`
- `features`: `ezmatrix` with three columns: `name`, `weight` and `price`

### Query
Fields of that type return a list of `ProductFeaturesRow`.

```
{
  content {
    product(contentId: 123) {
      name
      features {
        name
        price
      }
    }
  }
}
```

### Field Definition
The field definition settings, including columns, can be queried:
```
{
  content {
    _types {
      product {
        features {
          settings {
            minimumRows
            columns {
              name
              identifier
            }
          }
        }
      }
    }
  }
}
```

### Mutation
Fields of that type expect a `ProductFeaturesRowInput`.

```
mutation AddProduct {
  createProduct(
    parentLocationId: $parentLocationId,
    input: {
      name: "test",
      features: [
        {name: "foo", weight: "200", price: "20"}
        {name: "bar", weight: "300", price: "15"}
      ]
    }
  ) {
    name
  }
}
```
### TODO
- [ ] ~An undefined index notice will be thrown if trying to query a column that is empty. Hard to solve (can't be solved on the column field, must be solved above).~ will be fixed in ezmatrix, see https://jira.ez.no/browse/EZP-31041.
- [x] Query schema + resolver
- [x] Mutation schema + resolver
- [x] Field definition schema + resolver
- [x] Rebase against master ? It would be nice to ship it on 2.5 if possible.