### PR TITLE
EZP-31271: Simplified access to field settings in the ezmatrix_field twig block

### DIFF
--- a/src/bundle/Resources/views/themes/admin/matrix_fieldtype/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/admin/matrix_fieldtype/content_fields.html.twig
@@ -1,5 +1,5 @@
 {% block ezmatrix_field %}
-    {% set columnsSettings = content.contentType.fieldDefinitionsByIdentifier[field.fieldDefIdentifier].fieldSettings['columns'] %}
+    {% set columnsSettings = fieldSettings['columns'] %}
     {% set fieldData = field.value.rows %}
 
     <table class="ez-table table">

--- a/src/bundle/Resources/views/themes/standard/matrix_fieldtype/content_fields.html.twig
+++ b/src/bundle/Resources/views/themes/standard/matrix_fieldtype/content_fields.html.twig
@@ -1,6 +1,6 @@
 {% block ezmatrix_field %}
 {% apply spaceless %}
-    {% set columnsSettings = content.contentType.fieldDefinitionsByIdentifier[field.fieldDefIdentifier].fieldSettings['columns'] %}
+    {% set columnsSettings = fieldSettings['columns'] %}
     {% set fieldData = field.value.rows %}
 
     <table>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-31271

## Description 

Inside the `*_field` blocks `fieldSettings` variable exposes settings of the currently rendered field. 

Also `\eZ\Publish\Core\Repository\Values\ContentType\ContentType::$fieldDefinitionsByIdentifier` is not part of the API and shouldn't be used here. Ref. https://github.com/ezsystems/ezpublish-kernel/blob/7.5/eZ/Publish/Core/Repository/Values/ContentType/ContentType.php#L60-L65 

On the `master` branch this causes the following error:

```
Neither the property "fieldDefinitionsByIdentifier" nor one of the methods "fieldDefinitionsByIdentifier()", "getfieldDefinitionsByIdentifier()"/"isfieldDefinitionsByIdentifier()"/"hasfieldDefinitionsByIdentifier()" or "__call()" exist and have public access in class "eZ\Publish\Core\Repository\Values\ContentType\ContentType".
```

as the `\eZ\Publish\Core\Repository\Values\ContentType\ContentType::$fieldDefinitionsByIdentifier` is not longer available. See. https://github.com/ezsystems/ezpublish-kernel/pull/2839/files#diff-44fda21f8491726bee83781572e6e99bL60-L65