### PR TITLE
Translation configuration name has been unified

### DIFF
--- a/src/bundle/DependencyInjection/EzPlatformMatrixFieldtypeExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformMatrixFieldtypeExtension.php
@@ -64,7 +64,7 @@ class EzPlatformMatrixFieldtypeExtension extends Extension implements PrependExt
     {
         $container->prependExtensionConfig('jms_translation', [
             'configs' => [
-                'matrix_fieldtype' => [
+                'ezplatform_matrix_fieldtype' => [
                     'dirs' => [
                         __DIR__ . '/../../',
                     ],


### PR DESCRIPTION
In other packages we have a sufix `ezplatform` for translation configuration names