### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^7.3",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
         "ezsystems/ezplatform-content-forms": "^1.0@dev",
         "ezsystems/ezplatform-graphql": "^2.0@dev",
         "symfony/http-kernel": "^5.0",

--- a/tests/integration/CoreSetupFactoryTrait.php
+++ b/tests/integration/CoreSetupFactoryTrait.php
@@ -19,9 +19,9 @@ use Symfony\Component\DependencyInjection\Reference;
 trait CoreSetupFactoryTrait
 {
     /**
-     * Load ezpublish-kernel settings and setup container.
+     * Load eZ Platform Kernel settings and setup container.
      *
-     * @todo refactor ezpublish-kernel SetupFactory to include that setup w/o relying on config.php
+     * @todo refactor ezplatform-kernel SetupFactory to include that setup w/o relying on config.php
      *
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $containerBuilder
      *
@@ -30,9 +30,9 @@ trait CoreSetupFactoryTrait
     protected function loadCoreSettings(ContainerBuilder $containerBuilder)
     {
         // @todo refactor when refactoring kernel SetupFactory to avoid hardcoding package path
-        $kernelRootDir = realpath(__DIR__ . '/../../vendor/ezsystems/ezpublish-kernel');
+        $kernelRootDir = realpath(__DIR__ . '/../../vendor/ezsystems/ezplatform-kernel');
         if (false === $kernelRootDir) {
-            throw new RuntimeException('Unable to find the ezpublish-kernel package directory');
+            throw new RuntimeException('Unable to find the ezplatform-kernel package directory');
         }
         $settingsPath = "{$kernelRootDir}/eZ/Publish/Core/settings";
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | [yes](https://travis-ci.com/github/ezsystems/ezplatform-matrix-fieldtype/builds/154420560)
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel` and fixes dependency issues blocking package installation (due to Composer minimum stability requirements):

- `ezsystems/doctrine-dbal-schema:^1.0@dev` is required  by `ezplatform-kernel:^1.0@dev`
- other packages are required indirectly by `ezsystems/ezplatform-graphql:^2.0@dev` due to its dependency on `ezsystems/ezplatform-admin-ui:^2.0@dev`...

#### TODO
- [x] Wait for Travis