### PR TITLE
EZP-32259: Replaced "ezplatform" commands namespace with "ibexa"

### DIFF
--- a/src/bundle/Command/MigrateLegacyMatrixCommand.php
+++ b/src/bundle/Command/MigrateLegacyMatrixCommand.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformMatrixFieldtypeBundle\Command;
 
 use Doctrine\DBAL\Connection;
 use Exception;
+use eZ\Bundle\EzPublishCoreBundle\Command\BackwardCompatibleCommand;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
@@ -23,7 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class MigrateLegacyMatrixCommand extends Command
+class MigrateLegacyMatrixCommand extends Command implements BackwardCompatibleCommand
 {
     private const DEFAULT_ITERATION_COUNT = 1000;
 
@@ -31,7 +32,7 @@ class MigrateLegacyMatrixCommand extends Command
 
     private const CONFIRMATION_ANSWER = 'yes';
 
-    protected static $defaultName = 'ezplatform:migrate:legacy_matrix';
+    protected static $defaultName = 'ibexa:migrate:legacy_matrix';
 
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
@@ -53,6 +54,7 @@ class MigrateLegacyMatrixCommand extends Command
     protected function configure()
     {
         $this
+            ->setAliases(['ezplatform:migrate:legacy_matrix'])
             ->addOption(
                 'iteration-count',
                 'c',
@@ -344,5 +346,13 @@ class MigrateLegacyMatrixCommand extends Command
         );
 
         return $progressBar;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDeprecatedAliases(): array
+    {
+        return ['ezplatform:migrate:legacy_matrix'];
     }
 }

--- a/src/bundle/Command/MigrateLegacyMatrixCommand.php
+++ b/src/bundle/Command/MigrateLegacyMatrixCommand.php
@@ -32,8 +32,6 @@ class MigrateLegacyMatrixCommand extends Command implements BackwardCompatibleCo
 
     private const CONFIRMATION_ANSWER = 'yes';
 
-    protected static $defaultName = 'ibexa:migrate:legacy_matrix';
-
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
@@ -54,7 +52,8 @@ class MigrateLegacyMatrixCommand extends Command implements BackwardCompatibleCo
     protected function configure()
     {
         $this
-            ->setAliases(['ezplatform:migrate:legacy_matrix'])
+            ->setName('ibexa:migrate:legacy_matrix')
+            ->setAliases($this->getDeprecatedAliases())
             ->addOption(
                 'iteration-count',
                 'c',

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -1,5 +1,4 @@
 imports:
     - { resource: services/fieldtype.yaml }
-    - { resource: services/migration.yaml }
     - { resource: services/command.yaml }
     - { resource: services/graphql.yaml }

--- a/src/bundle/Resources/config/services/command.yaml
+++ b/src/bundle/Resources/config/services/command.yaml
@@ -5,5 +5,7 @@ services:
         public: false
 
     EzSystems\EzPlatformMatrixFieldtypeBundle\Command\MigrateLegacyMatrixCommand:
+        arguments:
+            - "@ezpublish.persistence.connection"
         tags:
-            - console.command
+            - { name: console.command }

--- a/src/bundle/Resources/config/services/command.yaml
+++ b/src/bundle/Resources/config/services/command.yaml
@@ -6,6 +6,6 @@ services:
 
     EzSystems\EzPlatformMatrixFieldtypeBundle\Command\MigrateLegacyMatrixCommand:
         arguments:
-            - "@ezpublish.persistence.connection"
+            - '@ezpublish.persistence.connection'
         tags:
             - { name: console.command }

--- a/src/bundle/Resources/config/services/migration.yaml
+++ b/src/bundle/Resources/config/services/migration.yaml
@@ -1,9 +1,0 @@
-services:
-    _defaults:
-        autoconfigure: true
-        autowire: true
-        public: false
-
-    EzSystems\EzPlatformMatrixFieldtypeBundle\Command\MigrateLegacyMatrixCommand:
-        arguments:
-            - "@ezpublish.persistence.connection"


### PR DESCRIPTION
> JIRA: [EZP-32259](https://jira.ez.no/browse/EZP-32259)

### Description 

Replaced "ezplatform" commands namespace with "ibexa" and removed duplicated  `EzSystems\EzPlatformMatrixFieldtypeBundle\Command\MigrateLegacyMatrixCommand` definition. Requires https://github.com/ezsystems/ezplatform-kernel/pull/153. 

## Checklist

- [X] Code follows the code style of this project (use `$ composer fix-cs`).
- [X] Change requires a change to the documentation.
- [X] Code is ready for a review.
