### PR TITLE
Added missing "ext-simplexml" and "ext-libxml" dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
     },
     "require": {
         "php": "^7.1",
+        "ext-libxml": "*",
+        "ext-simplexml": "*",
         "ezsystems/ezplatform-graphql": "^1.0.4@dev"
     },
     "require-dev": {


### PR DESCRIPTION
> JIRA: -

### Description

Both extensions are used by `\EzSystems\EzPlatformMatrixFieldtypeBundle\Command\MigrateLegacyMatrixCommand`