### PR TITLE
[CI] Removed adding credentials for private packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,15 +26,6 @@ jobs:
           extensions: 'pdo_sqlite, gd'
           tools: cs2pr
 
-      - name: Add composer keys for private packagist
-        run: |
-          composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
-          composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
-        env:
-          SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-          SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-          TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
-
       - uses: "ramsey/composer-install@v1"
         with:
           dependency-versions: "highest"


### PR DESCRIPTION
This is a public repository, this part is not needed